### PR TITLE
fix implicit casts for src/column.cpp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Authors@R: c(
     person("Greg", "Freedman Ellis", , "gfellis@umn.edu", c("aut", "cre")),
     person("Derek Burk", role = "ctb"),
     person("Joe Grover", role = "ctb"),
+    person("Mark Padgham", role = "ctb"),
     person("Hadley", "Wickham", , "hadley@rstudio.com", "ctb", comment = "Code adapted from readr"),
     person("Jim", "Hester", , "james.hester@rstudio.com", c("ctb"), comment = "Code adapted from readr"),
     person("Romain", "Francois", role = "ctb", comment = "Code adapted from readr"),

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -7,6 +7,7 @@ Contributors:
   Greg Freedman Ellis, Minnesota Population Center, University of Minnesota
   Joe Grover, Minnesota Population Center, University of Minnesota
   Derek Burk, Minnesota Population Center, University of Minnesota
+  Mark Padgham, University of Salzburg, Austria
 
 
 This project is licensed under the GPL (versions 2 or later) (the

--- a/src/column.h
+++ b/src/column.h
@@ -21,6 +21,7 @@ protected:
 public:
   Column(SEXP values) :
     values_(values), n_(0), failure_count_(0){}
+  virtual ~Column () = 0;
 
   virtual void setValue(int i, const char* x_start, const char* x_end) = 0;
 
@@ -62,6 +63,7 @@ public:
   ColumnCharacter(Rcpp::List opts_) : Column(Rcpp::CharacterVector()) {
     trim_ws = opts_["trim_ws"];
   }
+  virtual ~ColumnCharacter () = 0;
   void setValue(int i, const char* x_start, const char* x_end);
   std::string getType() {return "character";}
 };


### PR DESCRIPTION
@gergness The first things that usually jump out are implicit typecasts. You can catch all of these with a `~/.R/Makevars` file like this:
```
VER=
CCACHE=ccache
CCACHE=
COMPXX=clang++
COMP=clang
#COMPXX=g++
#COMP=g++

EXCL_A=/usr/local/lib/R/site-library/Rcpp/include
EXCL_B=/usr/local/lib/R/site-library/RcppArmadillo/include
EXCL_C=/usr/local/lib/R/site-library/RcppParallel/include
EXCL_D=/usr/local/lib/R/site-library/BH/include

CXX=$(CCACHE) $(COMPXX)$(VER)
CXXFLAGS= -Wall -pedantic -Wconversion -isystem $(EXCL_A) -isystem $(EXCL_B) -isystem $(EXCL_C) -isystem $(EXCL_D)
#CXXFLAGS= -Wall -pedantic

CXX11=$(CCACHE) $(COMPXX)$(VER)
CXX11FLAGS= -Wall -pedantic -Wconversion -isystem $(EXCL_A) -isystem $(EXCL_B) -isystem $(EXCL_C) -isystem $(EXCL_D)
#CXX11FLAGS= -Wall -pedantic

CXX14=$(CCACHE) $(COMPXX)$(VER)
CXX14FLAGS= -Wall -pedantic -Wconversion -isystem $(EXCL_A) -isystem $(EXCL_B) -isystem $(EXCL_C) -isystem $(EXCL_D)
#CXX14FLAGS= -Wall -pedantic

CC=$(CCACHE) $(COMP)$(VER)

FC=$(CCACHE) gfortran$(VER)
F77=$(CCACHE) gfortran$(VER)
```
Revert back to the commented `-Wall -pedantic` for less verbose output, and you'll sometimes have to revert to `g++` for installation/update of some R packages. This PR fixes them for `column.cpp` - I'll leave it to you to do the rest, and get on with looking a bit deeper.