### PR TITLE
Pr2 continue

### DIFF
--- a/src/Progress.h
+++ b/src/Progress.h
@@ -34,6 +34,8 @@ public:
         show_(false),
         stopped_(false) {}
 
+  Progress(const Progress &x) = default;
+
   void stop() {
     timeStop_ = now();
     stopped_ = true;
@@ -52,7 +54,7 @@ public:
     }
 
     std::stringstream labelStream;
-    tfm::format(labelStream, " %3d%%", (int)(prop * 100));
+    tfm::format(labelStream, " %3d%%", static_cast<int>(prop * 100));
     if (size > 0) {
       tfm::format(labelStream, " %4.0f MB", size);
     }

--- a/src/Progress.h
+++ b/src/Progress.h
@@ -5,9 +5,9 @@
 #include <sstream>
 #include <time.h>
 
-inline int now() { return clock() / CLOCKS_PER_SEC; }
+inline int now() { return static_cast<int>(clock() / CLOCKS_PER_SEC); }
 
-inline std::string clearLine(int width = 50) {
+inline std::string clearLine(char width = 50) {
   return "\r" + std::string(' ', width) + "\r";
 }
 
@@ -59,12 +59,12 @@ public:
 
     std::string label = labelStream.str();
 
-    int barSize = width_ - label.size() - 2;
+    double barSize = static_cast<double>(width_ - static_cast<int>(label.size()) - 2);
     if (barSize < 0) {
       return;
     }
-    int nbars = prop * barSize;
-    int nspaces = (1 - prop) * barSize;
+    size_t nbars = static_cast<size_t>(prop * barSize);
+    size_t nspaces = static_cast<size_t>((1 - prop) * barSize);
     std::string bars(nbars, '='), spaces(nspaces, ' ');
     Rcpp::Rcout << '\r' << '|' << bars << spaces << '|' << label;
   }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,13 +6,13 @@
 using namespace Rcpp;
 
 // read_chunked_long
-void read_chunked_long(CharacterVector filename, Environment callback, NumericVector chunksize, CharacterVector var_names, CharacterVector var_types, List rt_info_, List var_pos_info_, List var_opts_, bool isGzipped, bool progress);
+void read_chunked_long(CharacterVector filename, Environment callback, int chunksize, CharacterVector var_names, CharacterVector var_types, List rt_info_, List var_pos_info_, List var_opts_, bool isGzipped, bool progress);
 RcppExport SEXP _hipread_read_chunked_long(SEXP filenameSEXP, SEXP callbackSEXP, SEXP chunksizeSEXP, SEXP var_namesSEXP, SEXP var_typesSEXP, SEXP rt_info_SEXP, SEXP var_pos_info_SEXP, SEXP var_opts_SEXP, SEXP isGzippedSEXP, SEXP progressSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type filename(filenameSEXP);
     Rcpp::traits::input_parameter< Environment >::type callback(callbackSEXP);
-    Rcpp::traits::input_parameter< NumericVector >::type chunksize(chunksizeSEXP);
+    Rcpp::traits::input_parameter< int >::type chunksize(chunksizeSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type var_names(var_namesSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type var_types(var_typesSEXP);
     Rcpp::traits::input_parameter< List >::type rt_info_(rt_info_SEXP);

--- a/src/column.cpp
+++ b/src/column.cpp
@@ -27,10 +27,9 @@ ColumnPtr Column::create(std::string type, Rcpp::List var_opts) {
 void Column::add_failure(int line_number, const char* x_start, const char* x_end) {
   if (++failure_count_ <= 5) {
     std::string value;
-    //value.assign(x_start, x_end - x_start);
-    std::size_t x_diff = reinterpret_cast<size_t>(x_end) -
-        reinterpret_cast<size_t>(x_start);
-    value.assign(x_start, reinterpret_cast<const char*>(x_diff));
+    size_t x_diff = static_cast<size_t>(x_end - x_start);
+    value.assign(x_start, x_diff);
+
     failure_values_.push_back(value);
     failure_rows_.push_back(line_number + 1);
   }

--- a/src/column.cpp
+++ b/src/column.cpp
@@ -7,6 +7,10 @@
 #include <Rcpp.h>
 using namespace Rcpp;
 
+std::string Column::getType() {
+  return "unknown";
+}
+
 ColumnPtr Column::create(std::string type, Rcpp::List var_opts) {
   if (type == "character") {
     return ColumnPtr(new ColumnCharacter(var_opts));
@@ -61,7 +65,7 @@ void ColumnCharacter::setValue(int i, const char* x_start, const char* x_end) {
 }
 
 void ColumnDouble::setValue(int i, const char* x_start, const char* x_end) {
-  long double value;
+  double value;
   IpStringUtils::newtrim(x_start, x_end);
   bool success;
   if (x_start == x_end) {
@@ -118,15 +122,6 @@ void resizeAllColumns(std::vector<ColumnPtr>& columns, int n) {
     columns[i]->resize(n);
   }
 }
-
-void clearAllColumns(std::vector<ColumnPtr>& columns, int n) {
-  size_t num_cols = columns.size();
-
-  for (size_t i = 0; i < num_cols; ++i) {
-    columns[i]->resize(0);
-  }
-}
-
 
 static Function as_tibble("as_tibble", Environment::namespace_env("tibble"));
 

--- a/src/column.h
+++ b/src/column.h
@@ -21,11 +21,11 @@ protected:
 public:
   Column(SEXP values) :
     values_(values), n_(0), failure_count_(0){}
-  virtual ~Column () = 0;
+  virtual ~Column() {}
 
   virtual void setValue(int i, const char* x_start, const char* x_end) = 0;
 
-  virtual std::string getType() {return "unknown";}
+  virtual std::string getType();
 
   int size() {
     return n_;
@@ -63,7 +63,7 @@ public:
   ColumnCharacter(Rcpp::List opts_) : Column(Rcpp::CharacterVector()) {
     trim_ws = opts_["trim_ws"];
   }
-  virtual ~ColumnCharacter () = 0;
+  ~ColumnCharacter() {}
   void setValue(int i, const char* x_start, const char* x_end);
   std::string getType() {return "character";}
 };
@@ -75,6 +75,7 @@ public:
   ColumnDouble(Rcpp::List opts_) : Column(Rcpp::DoubleVector()) {
     imp_dec = opts_["imp_dec"];
   }
+  ~ColumnDouble() {}
   void setValue(int i, const char* x_start, const char* x_end);
   std::string getType() {return "double";}
 };
@@ -83,13 +84,13 @@ public:
 class ColumnInteger : public Column {
 public:
   ColumnInteger(Rcpp::List opts_) : Column(Rcpp::IntegerVector()) {}
+  ~ColumnInteger() {}
   void setValue(int i, const char* x_start, const char* x_end);
   std::string getType() {return "integer";}
 };
 
 std::vector<ColumnPtr> createAllColumns(Rcpp::CharacterVector types, Rcpp::List var_opts);
 void resizeAllColumns(std::vector<ColumnPtr>& columns, int n);
-void clearAllColumns(std::vector<ColumnPtr>&);
 Rcpp::RObject columnsToDf(std::vector<ColumnPtr> columns, Rcpp::CharacterVector names);
 
 #endif

--- a/src/datasource.cpp
+++ b/src/datasource.cpp
@@ -7,8 +7,15 @@ using namespace Rcpp;
 #include "boost.h"
 #include "datasource.h"
 
+// This should never be called, but I include it here to avoid
+// -Weverything warning about no out-of-line virtual class defintions
+void DataSource::getLine(const char* &start, const char* &end) {
+  start = nullptr;
+  end = nullptr;
+}
+
 void FileDataSource::getLine(const char* &start, const char* &end) {
-  if (cur_end != NULL) cur_begin = cur_end + 1;
+  if (cur_end != nullptr) cur_begin = cur_end + 1;
   cur_end = std::find_if(cur_begin, file_end, [](int ch) {
     return ch == '\n';
   });
@@ -27,7 +34,7 @@ std::pair<double, size_t> FileDataSource::progress_info() {
     return std::make_pair(1.0, total_size_);
   } else {
     size_t current = static_cast<size_t>(cur_begin - file_begin);
-    return std::make_pair(current / (double)(total_size_), current);
+    return std::make_pair(current / static_cast<double>(total_size_), current);
   }
 }
 
@@ -50,7 +57,7 @@ std::pair<double, size_t> GzFileDataSource::progress_info() {
     return std::make_pair(1.0, total_size_);
   } else {
     size_t current = data_->getProgress() ;
-    return std::make_pair(current / (double)(total_size_), current);
+    return std::make_pair(current / static_cast<double>(total_size_), current);
   }
 }
 

--- a/src/datasource.cpp
+++ b/src/datasource.cpp
@@ -26,7 +26,7 @@ std::pair<double, size_t> FileDataSource::progress_info() {
   if (isDone()) {
     return std::make_pair(1.0, total_size_);
   } else {
-    size_t current = cur_begin - file_begin;
+    size_t current = static_cast<size_t>(cur_begin - file_begin);
     return std::make_pair(current / (double)(total_size_), current);
   }
 }

--- a/src/datasource.h
+++ b/src/datasource.h
@@ -3,7 +3,6 @@
 #define HIPREAD_DATASOURCE_H_
 
 #include <Rcpp.h>
-using namespace Rcpp;
 #include <fstream>
 #include <iostream>
 #include "boost.h"
@@ -16,9 +15,9 @@ typedef boost::shared_ptr<DataSource> DataSourcePtr;
 class DataSource {
   std::string filename_;
 public:
-  DataSource(std::string filename) : filename_(filename){};
-  virtual ~DataSource(){};
-  virtual void getLine(const char* &start, const char* &end) = 0;
+  DataSource(std::string filename) : filename_(filename){}
+  virtual ~DataSource(){}
+  virtual void getLine(const char* &start, const char* &end);
   virtual bool isDone() = 0;
   virtual std::pair<double, size_t> progress_info() = 0;
 };
@@ -49,13 +48,13 @@ public:
     file_begin = static_cast<char*>(mr_.get_address());
     file_end = file_begin + total_size_;
     cur_begin = file_begin;
-    cur_end = NULL;
-  };
+    cur_end = nullptr;
+  }
   ~FileDataSource() {
-    file_end = NULL;
-    file_begin = NULL;
-    cur_begin = NULL;
-    cur_end = NULL;
+    file_end = nullptr;
+    file_begin = nullptr;
+    cur_begin = nullptr;
+    cur_end = nullptr;
   }
   void getLine(const char* &start, const char* &end);
   bool isDone();
@@ -74,7 +73,7 @@ public:
   GzFileDataSource(std::string filename) : DataSource(filename) {
     data_ = new GzStream(filename);
     total_size_ = get_size();
-  };
+  }
   ~GzFileDataSource() {
     if (data_) delete data_;
   }

--- a/src/gzstream.cpp
+++ b/src/gzstream.cpp
@@ -10,7 +10,7 @@ using namespace Rcpp;
 void GzStream::fillBuffer() {
   int err;
   char* offset;
-  if (cur != NULL) {
+  if (cur != nullptr) {
     offset = std::copy(cur, end, buffer);
   } else {
     offset = buffer;

--- a/src/gzstream.cpp
+++ b/src/gzstream.cpp
@@ -16,10 +16,11 @@ void GzStream::fillBuffer() {
     offset = buffer;
   }
 
-  int len = sizeof(buffer) - (offset - buffer);
-  if (len <= 0) stop("Line length too long; cannot read file.");
+  uint buffer_size = sizeof(buffer);
+  uint overflow = static_cast<uint>(offset - buffer);
+  if (overflow > buffer_size) stop("Line length too long; cannot read file.");
 
-  len = gzread(file, offset, len);
+  int len = gzread(file, offset, buffer_size - overflow);
 
   if (len < 0) stop(gzerror(file, &err));
 
@@ -47,7 +48,6 @@ bool GzStream::getLine(const char* &line_start, const char* &line_end) {
   }
   line_start = cur;
   line_end = eol;
-  total_read_ += (eol - cur);
   cur = eol + 1;
   return true;
 }
@@ -59,12 +59,12 @@ bool GzStream::isDone() {
 size_t GzStream::getTotalSizeEstimate() {
   std::ifstream raw_(filename_);
   raw_.seekg(0, std::ifstream::end);
-  size_t total_file_bytes = raw_.tellg();
+  size_t total_file_bytes = static_cast<size_t>(raw_.tellg());
 
   return total_file_bytes;
 }
 
 size_t GzStream::getProgress() {
-  size_t out = gzoffset(file);
+  size_t out = static_cast<size_t>(gzoffset(file));
   return out;
 }

--- a/src/gzstream.h
+++ b/src/gzstream.h
@@ -21,12 +21,11 @@ private:
   char buffer[BUFLEN];
   char* cur;
   char* end;
-  size_t total_read_;
   void fillBuffer();
   bool done;
 
 public:
-  GzStream(std::string filename) : filename_(filename), total_read_(0), done(false) {
+  GzStream(std::string filename) : filename_(filename), done(false) {
     cur = NULL;
     file = gzopen(filename.c_str(), "rb");
     fillBuffer();

--- a/src/gzstream.h
+++ b/src/gzstream.h
@@ -1,8 +1,6 @@
 #ifndef HIPREAD_GZSTREAM_H_
 #define HIPREAD_GZSTREAM_H_
 
-#include <Rcpp.h>
-using namespace Rcpp;
 #include <zlib.h>
 #include <iostream>
 #include <algorithm>
@@ -26,13 +24,13 @@ private:
 
 public:
   GzStream(std::string filename) : filename_(filename), done(false) {
-    cur = NULL;
+    cur = nullptr;
     file = gzopen(filename.c_str(), "rb");
     fillBuffer();
-  };
+  }
   ~GzStream() {
-    cur = NULL;
-    end = NULL;
+    cur = nullptr;
+    end = nullptr;
   }
   bool getLine(const char* &line_start, const char* &line_end);
   bool isDone();

--- a/src/read_chunked.cpp
+++ b/src/read_chunked.cpp
@@ -9,10 +9,10 @@
 using namespace Rcpp;
 
 
-Function R6method(Environment env, const std::string& method) {
+static Function R6method(Environment env, const std::string& method) {
   return as<Function>(env[method]);
 }
-bool isTrue(SEXP x) {
+static bool isTrue(SEXP x) {
   if (!(TYPEOF(x) == LGLSXP && Rf_length(x) == 1)) {
     stop("`continue()` must return a length 1 logical vector");
   }

--- a/src/read_full.cpp
+++ b/src/read_full.cpp
@@ -45,11 +45,12 @@ RObject read_long(
 
     if (i >= out[0]->size()) {
       // Resize by guessing from the progress bar
-      resizeAllColumns(out, (i / data->progress_info().first) * 1.1);
+      resizeAllColumns(out, static_cast<int>((i / data->progress_info().first) * 1.1));
     }
 
-    int rt_index = rts.getRtIndex(line_start, line_end);
-    if (rt_index < 0) {
+    size_t rt_index;
+    bool rt_found = rts.getRtIndex(line_start, line_end, rt_index);
+    if (!rt_found) {
       // TODO: Should this be a warning?
       continue;
     }
@@ -60,11 +61,11 @@ RObject read_long(
     }
 
     // Loop through vars in rectype and add to out
-    for (int j = 0; j < vars.get_num_vars(rt_index); j++) {
+    for (size_t j = 0; j < vars.get_num_vars(rt_index); j++) {
       const char *x_start = line_start + vars.get_start(rt_index, j);
       const char *x_end = x_start + vars.get_width(rt_index, j);
 
-      int cur_var_pos = vars.get_var_pos(rt_index, j);
+      size_t cur_var_pos = vars.get_var_pos(rt_index, j);
 
       out[cur_var_pos]->setValue(i, x_start, x_end);
     }

--- a/src/rtinfo.cpp
+++ b/src/rtinfo.cpp
@@ -14,7 +14,9 @@ bool RtInfo::getRtIndex(const char* line_start, const char* line_end, size_t& ou
     out = 0;
     return true;
   }
-
+  if (line_start + start + width > line_end) {
+    Rcpp::stop("rectype variable cannot be longer than line.");
+  }
   std::string rt(line_start + start, line_start + start + width);
 
   long rt_pos = std::distance(
@@ -22,7 +24,7 @@ bool RtInfo::getRtIndex(const char* line_start, const char* line_end, size_t& ou
     std::find(rectypes.begin(), rectypes.end(), rt)
   );
   if (rt_pos < 0) Rcpp::stop("Could not parse rectype");
-  if (rt_pos == rectypes.size()) return false;
+  if (static_cast<size_t>(rt_pos) == rectypes.size()) return false;
   out = static_cast<size_t>(rt_pos);
   return true;
 }

--- a/src/rtinfo.cpp
+++ b/src/rtinfo.cpp
@@ -9,20 +9,24 @@ RtInfo::RtInfo(List rt_info, std::vector<std::string> rectypes_) : rectypes(rect
   hierarchical = width > 0;
 }
 
-int RtInfo::getRtIndex(const char* line_start, const char* line_end) {
-  if (!hierarchical) return 0;
+bool RtInfo::getRtIndex(const char* line_start, const char* line_end, size_t& out) {
+  if (!hierarchical) {
+    out = 0;
+    return true;
+  }
 
   std::string rt(line_start + start, line_start + start + width);
 
-  int rt_index = std::distance(
+  long rt_pos = std::distance(
     rectypes.begin(),
     std::find(rectypes.begin(), rectypes.end(), rt)
   );
-
-  if (rt_index == rectypes.size()) rt_index = -1;
-  return rt_index;
+  if (rt_pos < 0) Rcpp::stop("Could not parse rectype");
+  if (rt_pos == rectypes.size()) return false;
+  out = static_cast<size_t>(rt_pos);
+  return true;
 }
 
-int RtInfo::getNumRts() {
+size_t RtInfo::getNumRts() {
   return rectypes.size();
 }

--- a/src/rtinfo.h
+++ b/src/rtinfo.h
@@ -13,8 +13,8 @@ private:
 
 public:
   RtInfo(List rt_info, std::vector<std::string> rectypes_);
-  int getRtIndex(const char* line_start, const char* line_end);
-  int getNumRts();
+  bool getRtIndex(const char* line_start, const char* line_end, size_t& out);
+  size_t getNumRts();
 };
 
 #endif

--- a/src/rtinfo.h
+++ b/src/rtinfo.h
@@ -2,7 +2,6 @@
 #define HIPREAD_RTINFO_H_
 
 #include <Rcpp.h>
-using namespace Rcpp;
 
 class RtInfo {
 private:
@@ -12,7 +11,7 @@ private:
   bool hierarchical;
 
 public:
-  RtInfo(List rt_info, std::vector<std::string> rectypes_);
+  RtInfo(Rcpp::List rt_info, std::vector<std::string> rectypes_);
   bool getRtIndex(const char* line_start, const char* line_end, size_t& out);
   size_t getNumRts();
 };

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -6,7 +6,7 @@
 // Adapted from readr's QiParsers.h
 template <typename Iterator, typename Attr>
 inline bool parseDouble(Iterator& first, Iterator& last, Attr& res) {
-  return boost::spirit::qi::parse(first, last, boost::spirit::qi::long_double, res);
+  return boost::spirit::qi::parse(first, last, boost::spirit::qi::double_, res);
 }
 
 template <typename Iterator, typename Attr>

--- a/src/varinfo.cpp
+++ b/src/varinfo.cpp
@@ -3,11 +3,11 @@
 using namespace Rcpp;
 
 VarInfo::VarInfo(List var_pos_info, size_t num_rt) {
-  for (int i = 0; i < num_rt; i++) {
+  for (int i = 0; i < static_cast<int>(num_rt); i++) {
     starts.push_back(as<List>(var_pos_info[i])["start"]);
     widths.push_back(as<List>(var_pos_info[i])["width"]);
     var_pos.push_back(as<List>(var_pos_info[i])["var_pos"]);
-    num_vars_rectype.push_back(static_cast<int>(starts[static_cast<size_t>(i)].size()));
+    num_vars_rectype.push_back(starts[static_cast<size_t>(i)].size());
     max_ends.push_back(as<IntegerVector>(as<List>(var_pos_info[i])["max_end"])[0]);
   }
 }
@@ -24,7 +24,7 @@ size_t VarInfo::get_var_pos(size_t rt_index, size_t col_num) {
   return var_pos[rt_index][col_num];
 }
 
-int VarInfo::get_num_vars(size_t rt_index) {
+size_t VarInfo::get_num_vars(size_t rt_index) {
   return num_vars_rectype[rt_index];
 }
 

--- a/src/varinfo.cpp
+++ b/src/varinfo.cpp
@@ -2,32 +2,32 @@
 #include <Rcpp.h>
 using namespace Rcpp;
 
-VarInfo::VarInfo(List var_pos_info, int num_rt) {
+VarInfo::VarInfo(List var_pos_info, size_t num_rt) {
   for (int i = 0; i < num_rt; i++) {
     starts.push_back(as<List>(var_pos_info[i])["start"]);
     widths.push_back(as<List>(var_pos_info[i])["width"]);
     var_pos.push_back(as<List>(var_pos_info[i])["var_pos"]);
-    num_vars_rectype.push_back(starts[i].size());
+    num_vars_rectype.push_back(static_cast<int>(starts[static_cast<size_t>(i)].size()));
     max_ends.push_back(as<IntegerVector>(as<List>(var_pos_info[i])["max_end"])[0]);
   }
 }
 
-int VarInfo::get_start(int rt_index, int col_num) {
+int VarInfo::get_start(size_t rt_index, size_t col_num) {
   return starts[rt_index][col_num];
 }
 
-int VarInfo::get_width(int rt_index, int col_num) {
+int VarInfo::get_width(size_t rt_index, size_t col_num) {
   return widths[rt_index][col_num];
 }
 
-int VarInfo::get_var_pos(int rt_index, int col_num) {
+size_t VarInfo::get_var_pos(size_t rt_index, size_t col_num) {
   return var_pos[rt_index][col_num];
 }
 
-int VarInfo::get_num_vars(int rt_index) {
+int VarInfo::get_num_vars(size_t rt_index) {
   return num_vars_rectype[rt_index];
 }
 
-int VarInfo::get_max_end(int rt_index) {
+int VarInfo::get_max_end(size_t rt_index) {
   return max_ends[rt_index];
 }

--- a/src/varinfo.h
+++ b/src/varinfo.h
@@ -8,17 +8,17 @@ class VarInfo {
 private:
   std::vector<std::vector<int> > starts;
   std::vector<std::vector<int> > widths;
-  std::vector<std::vector<int> > var_pos;
+  std::vector<std::vector<size_t> > var_pos;
   std::vector<int> num_vars_rectype;
   std::vector<int> max_ends;
 
 public:
-  VarInfo(List var_pos_info, int num_rt);
-  int get_start(int rt_index, int col_num);
-  int get_width(int rt_index, int col_num);
-  int get_var_pos(int rt_index, int col_num);
-  int get_num_vars(int rt_index);
-  int get_max_end(int rt_index);
+  VarInfo(List var_pos_info, size_t num_rt);
+  int get_start(size_t rt_index, size_t col_num);
+  int get_width(size_t rt_index, size_t col_num);
+  size_t get_var_pos(size_t rt_index, size_t col_num);
+  int get_num_vars(size_t rt_index);
+  int get_max_end(size_t rt_index);
 };
 
 #endif

--- a/src/varinfo.h
+++ b/src/varinfo.h
@@ -2,22 +2,21 @@
 #define HIPREAD_VARINFO_H_
 
 #include <Rcpp.h>
-using namespace Rcpp;
 
 class VarInfo {
 private:
   std::vector<std::vector<int> > starts;
   std::vector<std::vector<int> > widths;
   std::vector<std::vector<size_t> > var_pos;
-  std::vector<int> num_vars_rectype;
+  std::vector<size_t> num_vars_rectype;
   std::vector<int> max_ends;
 
 public:
-  VarInfo(List var_pos_info, size_t num_rt);
+  VarInfo(Rcpp::List var_pos_info, size_t num_rt);
   int get_start(size_t rt_index, size_t col_num);
   int get_width(size_t rt_index, size_t col_num);
   size_t get_var_pos(size_t rt_index, size_t col_num);
-  int get_num_vars(size_t rt_index);
+  size_t get_num_vars(size_t rt_index);
   int get_max_end(size_t rt_index);
 };
 


### PR DESCRIPTION
Continues work done in #2 to reduce compiler warnings with stricter settings.

There are still quite a few warnings with -Weverything, but I think I've hit the important ones (most of the remaining ones are about padding or C++98 compatibility, neither of which do I think I need to care about). There are also a bunch in the RcppExports, but I don't think I need to worry about them.

The only set that I just don't understand is these, @mpadge let me know if you think I should fix (and even better, if you know how).
```
column.cpp:125:17: error: declaration requires an exit-time destructor [-Werror,-Wexit-time-destructors]
static Function as_tibble("as_tibble", Environment::namespace_env("tibble"));
                ^
column.cpp:125:17: error: declaration requires a global destructor [-Werror,-Wglobal-constructors]
```